### PR TITLE
Remove wilcards from the LDAP query filter

### DIFF
--- a/xivo_dird/directory/data_sources/ldap.py
+++ b/xivo_dird/directory/data_sources/ldap.py
@@ -74,7 +74,7 @@ class LDAPDirectoryDataSource(DirectoryDataSource):
         return ldap_search_filter.encode(self.ldap_encoding)
 
     def _compute_ldap_search_filter(self, search_pattern, fields):
-        ldap_filter = [u'(%s=*%s*)' % (field, search_pattern) for field in fields]
+        ldap_filter = [u'(%s=%s)' % (field, search_pattern) for field in fields]
         str_ldap_filter = u'(|%s)' % u''.join(ldap_filter)
         return str_ldap_filter
 


### PR DESCRIPTION
this fix replaces the prior misplaced fix in commit
f51911053285495590ffabf492b8208a01ec583 for "fix reverse lookup
partial patches - Only complete numbers are matched by a reverse
lookup" for the LDAP back-end. Other back-ends do not seem to use a
wildcard approach and are only looking for exact matches.